### PR TITLE
Issue #3  Security issues and small improvements

### DIFF
--- a/icmp.c
+++ b/icmp.c
@@ -174,12 +174,11 @@ void receive_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
   packet_details->type = icmp->type;
   packet_details->payload_size = packet_size - sizeof(struct iphdr) - sizeof(struct icmphdr);
   packet_details->payload = calloc(packet_details->payload_size, sizeof(uint8_t));
-  if (packet_details->payload_size == NULL) {
+  if (packet_details->payload == NULL) {
     printf("No memory available\n");
     close_icmp_socket(sock_fd);
     exit(-1);
   }
-
 
   memcpy(packet_details->payload, icmp_payload, packet_details->payload_size);
 

--- a/icmp.c
+++ b/icmp.c
@@ -101,13 +101,12 @@ void send_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
   inet_pton(AF_INET, packet_details->dest_addr, &dest_addr);
 
   packet_size = sizeof(struct iphdr) + sizeof(struct icmphdr) + packet_details->payload_size;
-  packet = (char *)malloc(packet_size);
+  packet = calloc(packet_size, sizeof(uint8_t));
   if (packet == NULL) {
     printf("No memory available\n");
     close_icmp_socket(sock_fd);
     exit(-1);
   }
-  memset(packet, 0, packet_size);
 
   // Initializing header and payload pointers
   ip = (struct iphdr *)packet;
@@ -153,8 +152,12 @@ void receive_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
 
   int src_addr_size;
 
-  packet = (char *)malloc(MTU);
-  memset(packet, 0, MTU);
+  packet = calloc(MTU, sizeof(uint8_t));
+  if (packet == NULL) {
+    printf("No memory available\n");
+    close_icmp_socket(sock_fd);
+    exit(-1);
+  }
 
   src_addr_size = sizeof(struct sockaddr_in);
   
@@ -170,7 +173,14 @@ void receive_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
   inet_ntop(AF_INET, &(ip->daddr), packet_details->dest_addr, INET_ADDRSTRLEN);
   packet_details->type = icmp->type;
   packet_details->payload_size = packet_size - sizeof(struct iphdr) - sizeof(struct icmphdr);
-  packet_details->payload = (char *)malloc(packet_details->payload_size);
+  packet_details->payload = calloc(packet_details->payload_size, sizeof(uint8_t));
+  if (packet_details->payload_size == NULL) {
+    printf("No memory available\n");
+    close_icmp_socket(sock_fd);
+    exit(-1);
+  }
+
+
   memcpy(packet_details->payload, icmp_payload, packet_details->payload_size);
 
   free(packet);

--- a/icmptunnel.c
+++ b/icmptunnel.c
@@ -5,9 +5,17 @@
 #include "tunnel.h"
 
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char *argv[])
 {
-  run_tunnel(argv[2], !strcmp(argv[1], "-s"));
+  char ip_addr[100] = {0,};
+  if ((strlen(argv[2]) + 1) > sizeof(ip_addr)){
+      printf("Bad ip argument\n");
+      exit(EXIT_FAILURE);
+  }
+  memcpy(ip_addr, argv[2], strlen(argv[2]) + 1);
+  run_tunnel(ip_addr, !strcmp(argv[1], "-s"));
   return 0;
 }

--- a/test_client.c
+++ b/test_client.c
@@ -11,8 +11,8 @@ int main()
   src_ip = "127.0.0.2";
   dest_ip = "127.0.0.1";
 
-  strcpy(packet.src_addr, src_ip);
-  strcpy(packet.dest_addr, dest_ip);
+  strncpy(packet.src_addr, src_ip, strlen(src_ip) + 1);
+  strncpy(packet.dest_addr, dest_ip, strlen(dest_ip) + 1);
   set_reply_type(&packet);
   packet.payload = "ZZZZZZ";
   packet.payload_size = strlen(packet.payload);

--- a/tunnel.c
+++ b/tunnel.c
@@ -20,6 +20,9 @@
 #include <pthread.h>
 #include <arpa/inet.h>
 
+
+#define DEFAULT_ROUTE   "0.0.0.0"
+
 /**
  * Function to allocate a tunnel
  */
@@ -104,10 +107,18 @@ void configure_network(int server)
   char *const args[] = {path, NULL};
 
   if (server) {
-    strcpy(path, SERVER_SCRIPT);
+    if (sizeof(SERVER_SCRIPT) > sizeof(path)){
+        printf("Server script path is too long\n");
+        exit(EXIT_FAILURE);
+    }
+    strncpy(path, SERVER_SCRIPT, strlen(SERVER_SCRIPT) + 1);
   }
   else {
-    strcpy(path, CLIENT_SCRIPT);
+    if (sizeof(CLIENT_SCRIPT) > sizeof(path)){
+        printf("Client script path is too long\n");
+        exit(EXIT_FAILURE);
+    }
+    strncpy(path, CLIENT_SCRIPT, strlen(CLIENT_SCRIPT) + 1);
   }
 
   pid = fork();
@@ -174,8 +185,23 @@ void run_tunnel(char *dest, int server)
       // Preparing ICMP packet to be sent
       memset(&packet, 0, sizeof(struct icmp_packet));
       printf("[DEBUG] Destination address: %s\n", dest);
-      strcpy(packet.src_addr, "0.0.0.0");
-      strcpy(packet.dest_addr, dest);
+
+      if (sizeof(DEFAULT_ROUTE) > sizeof(packet.src_addr)){
+        printf("Lack of space: size of DEFAULT_ROUTE > size of src_addr\n");
+        close(tun_fd);
+        close(sock_fd);
+        exit(EXIT_FAILURE);
+      }
+      strncpy(packet.src_addr, DEFAULT_ROUTE, sizeof(DEFAULT_ROUTE));
+
+      if (sizeof(DEFAULT_ROUTE) > sizeof(packet.dest_addr)){
+        printf("Lack of space for copy size of DEFAULT_ROUTE > size of dest_addr\n");
+        close(tun_fd);
+        close(sock_fd);
+        exit(EXIT_FAILURE);
+      }
+      strncpy(packet.dest_addr, dest, sizeof(DEFAULT_ROUTE));
+
       if(server) {
         set_reply_type(&packet);
       }
@@ -214,7 +240,7 @@ void run_tunnel(char *dest, int server)
       tun_write(tun_fd, packet.payload, packet.payload_size);
 
       printf("[DEBUG] Src address being copied: %s\n", packet.src_addr);
-      strcpy(dest, packet.src_addr);
+      strncpy(dest, packet.src_addr, strlen(packet.src_addr) + 1);
     }
   }
 

--- a/tunnel.c
+++ b/tunnel.c
@@ -192,15 +192,15 @@ void run_tunnel(char *dest, int server)
         close(sock_fd);
         exit(EXIT_FAILURE);
       }
-      strncpy(packet.src_addr, DEFAULT_ROUTE, sizeof(DEFAULT_ROUTE));
+      strncpy(packet.src_addr, DEFAULT_ROUTE, strlen(DEFAULT_ROUTE) + 1);
 
-      if (sizeof(DEFAULT_ROUTE) > sizeof(packet.dest_addr)){
+      if ((strlen(dest) + 1) > sizeof(packet.dest_addr)){
         printf("Lack of space for copy size of DEFAULT_ROUTE > size of dest_addr\n");
         close(tun_fd);
         close(sock_fd);
         exit(EXIT_FAILURE);
       }
-      strncpy(packet.dest_addr, dest, sizeof(DEFAULT_ROUTE));
+      strncpy(packet.dest_addr, dest, strlen(dest) + 1);
 
       if(server) {
         set_reply_type(&packet);

--- a/tunnel.c
+++ b/tunnel.c
@@ -182,7 +182,12 @@ void run_tunnel(char *dest, int server)
       else {
         set_echo_type(&packet);
       }
-      packet.payload = malloc(MTU);
+      packet.payload = calloc(MTU, sizeof(uint8_t));
+      if (packet.payload == NULL){
+        perror("No memory available\n");
+        exit(EXIT_FAILURE);
+      }
+
       packet.payload_size  = tun_read(tun_fd, packet.payload, MTU);
       if(packet.payload_size  == -1) {
         printf("Error while reading from tun device\n");


### PR DESCRIPTION
Hi,

Strncpy should be use in order to prevent nasty buffer overflows.

`tunnel.c: L:212` was subject to buffer overflow because `dest` is provided by user and can be smaller than `packet.src_addr`. We need a bigger memory allocation before calling `run_tunnel` and pass a copy pointer into this function.

I hope I can help this project, 'cause your job is nice!

Best regards

