### PR TITLE
Change the MTU size of tunnel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-I.
+CFLAGS=-I. -O3 -Wall
 DEPS = icmp.h tunnel.h
 
 %.o: %.c $(DEPS)

--- a/client.sh
+++ b/client.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Assigining an IP address and mask to 'tun0' interface
-ifconfig tun0 mtu 1500 up 10.0.1.2 netmask 255.255.255.0
+ifconfig tun0 mtu 1472 up 10.0.1.2 netmask 255.255.255.0
 
 # Modifying IP routing tables
 route del default

--- a/icmp.c
+++ b/icmp.c
@@ -142,7 +142,7 @@ void send_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
 void receive_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
 {
   struct sockaddr_in src_addr;
-  struct sockaddr_in dest_addr;
+  //struct sockaddr_in dest_addr;
 
   struct iphdr *ip;
   struct icmphdr *icmp;
@@ -151,9 +151,12 @@ void receive_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
   int packet_size;
   char *packet;
 
-  int src_addr_size;
+  socklen_t src_addr_size;
+  int enc_MTU; //encapsulated MTU
 
-  packet = calloc(MTU, sizeof(uint8_t));
+  enc_MTU = MTU + sizeof(struct iphdr) + sizeof(struct icmphdr);
+
+  packet = calloc(enc_MTU, sizeof(uint8_t));
   if (packet == NULL) {
     perror("No memory available\n");
     close_icmp_socket(sock_fd);
@@ -163,7 +166,7 @@ void receive_icmp_packet(int sock_fd, struct icmp_packet *packet_details)
   src_addr_size = sizeof(struct sockaddr_in);
   
   // Receiving packet
-  packet_size = recvfrom(sock_fd, packet, MTU, 0, (struct sockaddr *)&(src_addr), &src_addr_size);
+  packet_size = recvfrom(sock_fd, packet, enc_MTU, 0, (struct sockaddr *)&(src_addr), &src_addr_size);
 
   ip = (struct iphdr *)packet;
   icmp = (struct icmphdr *)(packet + sizeof(struct iphdr));

--- a/icmp.h
+++ b/icmp.h
@@ -6,7 +6,7 @@
 #define icmp_guard
 
 // Maximum transmission unit
-#define MTU 1500
+#define MTU 1472
 
 struct icmp_packet
 {

--- a/server.sh
+++ b/server.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Assigining an IP address and mask to 'tun0' interface
-ifconfig tun0 mtu 1500 up 10.0.1.1 netmask 255.255.255.0 
+ifconfig tun0 mtu 1472 up 10.0.1.1 netmask 255.255.255.0 
 
 # Preventing the kernel to reply to any ICMP pings
 echo 1 | dd of=/proc/sys/net/ipv4/icmp_echo_ignore_all


### PR DESCRIPTION
Since the ethernet MTU is up to 1500, if we add the ip and icmp header to the origin packet (read from tunnel), the packet size will up to 1528, and thus it cannot pass the ethernet without jumbo frame.

What I did is to decrease the MTU size of the tunnel to 1472, so that after we add the ip and icmp header to the packet, the maximum size of the packet won't be larger than 1500, thus it can fit the general ethernet scenario.