### PR TITLE
Free the unfree heap

### DIFF
--- a/tunnel.c
+++ b/tunnel.c
@@ -243,6 +243,7 @@ void run_tunnel(char *dest, int server)
 
       printf("[DEBUG] Src address being copied: %s\n", packet.src_addr);
       strncpy(dest, packet.src_addr, strlen(packet.src_addr) + 1);
+      free(packet.payload);
     }
   }
 


### PR DESCRIPTION
I just found that if I kept using the tunnel for a while, about 30 minutes, both memory and heap is full-load. So I checked out the code, I found there was a unfree heap after a calloc(). I just freed it and now it works well.